### PR TITLE
Datetime object already is tz aware

### DIFF
--- a/meteomatics/api.py
+++ b/meteomatics/api.py
@@ -837,9 +837,6 @@ def query_init_date(startdate, enddate, interval, parameter, username, password,
     except:
         raise WeatherApiException(response.text)
 
-    # mark index as UTC timezone
-    df.index = df.index.tz_localize("UTC")
-
     return df
 
 

--- a/meteomatics/api.py
+++ b/meteomatics/api.py
@@ -837,6 +837,12 @@ def query_init_date(startdate, enddate, interval, parameter, username, password,
     except:
         raise WeatherApiException(response.text)
 
+    try: 
+        # mark index as UTC timezone
+        df.index = df.index.tz_localize("UTC")
+    except TypeError:
+        pass
+
     return df
 
 


### PR DESCRIPTION
Prevents an exception with "Failed, the exception is Already tz-aware, use tz_convert to convert.", as the downloaded datetime already is tz aware

Are there also some tests available?