### PR TITLE
No need for manualy passing message to Exception

### DIFF
--- a/meteomatics/exceptions.py
+++ b/meteomatics/exceptions.py
@@ -4,8 +4,7 @@ from collections import defaultdict
 
 
 class WeatherApiException(Exception):
-    def __init__(self, message):
-        super(WeatherApiException, self).__init__(message)
+    pass
 
 
 class BadRequest(WeatherApiException):


### PR DESCRIPTION
Its not necessary to manually pass the message from the WeatherApiException.__init__() method to the Exception.__init__() method.