### PR TITLE
Add option for specifying a mask

### DIFF
--- a/meteomatics/api.py
+++ b/meteomatics/api.py
@@ -463,7 +463,7 @@ def query_lightnings(startdate, enddate, lat_N, lon_W, lat_S, lon_E, username, p
 
 def query_netcdf(filename, startdate, enddate, interval, parameter_netcdf, lat_N, lon_W, lat_S, lon_E, res_lat, res_lon,
                  username, password, model=None, ens_select=None, interp_select=None,
-                 api_base_url=DEFAULT_API_BASE_URL, request_type='GET', cluster_select=None):
+                 api_base_url=DEFAULT_API_BASE_URL, request_type='GET', cluster_select=None, mask=None):
     """Queries a netCDF file form the Meteomatics API and stores it in filename.
     request_type is one of 'GET'/'POST'
     """
@@ -474,7 +474,7 @@ def query_netcdf(filename, startdate, enddate, interval, parameter_netcdf, lat_N
 
     # build URL
     url_params_dict = parse_time_series_params(model=model, ens_select=ens_select, cluster_select=cluster_select,
-                                               interp_select=interp_select)
+                                               interp_select=interp_select,mask=mask)
     url = NETCDF_TEMPLATE.format(
         api_base_url=api_base_url,
         startdate=startdate.isoformat(),

--- a/meteomatics/parsing_util.py
+++ b/meteomatics/parsing_util.py
@@ -308,7 +308,7 @@ def parse_query_station_timeseries_params(model=None, on_invalid=None, temporal_
     return filter_none_from_dict(url_params_dict)
 
 
-def parse_time_series_params(model=None, ens_select=None, cluster_select=None, interp_select=None, on_invalid=None,
+def parse_time_series_params(model=None, ens_select=None, cluster_select=None, interp_select=None, mask=None, on_invalid=None,
                              kwargs=None):
     url_params_dict = {
         'connector': VERSION,
@@ -316,6 +316,7 @@ def parse_time_series_params(model=None, ens_select=None, cluster_select=None, i
         'ens_select': ens_select,
         'cluster_select': cluster_select,
         'interp_select': interp_select,
+        'mask': mask,
         'on_invalid': on_invalid,
     }
     if kwargs is not None:


### PR DESCRIPTION
Added the optional argument "mask" to the query_netcdf() function and subsequently to the parse_time_series_params() function. This allows a user to download masked netcdf files. First tests show good results. If mask="Land" then the oceans are masked by -666.