### PR TITLE
allows to understand if the timeout comes from API or somewhere else

### DIFF
--- a/meteomatics/api.py
+++ b/meteomatics/api.py
@@ -101,7 +101,7 @@ def create_path(_file):
         os.makedirs(_path)
 
 
-def query_api(url, username, password, request_type="GET", timeout_seconds=300,
+def query_api(url, username, password, request_type="GET", timeout_seconds=330,
               headers={'Accept': 'application/octet-stream'}):
     if request_type.lower() == "get":
         _logger.debug("Calling URL: {} (username = {})".format(url, username))


### PR DESCRIPTION
There are 2 issues having the timeout set exactly at the max timeout of our API:
1. The connectors may fail with "timeout" even if API does not (we do not consider transfer time).
2. There were cases where the timeout was coming form the LB (because of errors in customers scripts) that were hard to debug because the script (before this commit) would never show the timeout coming from API but just a generic timeout coming from python.