### PR TITLE
Update connector version to 2.11.6 -> 3.0.0

### DIFF
--- a/meteomatics/__version__.py
+++ b/meteomatics/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "2.11.6"
+__version__ = "3.0.0"


### PR DESCRIPTION
We update to v3.0.0 mainly because we drop the compatibility to Python 2.